### PR TITLE
fix: execute scripts from another script using yarn

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "env-check": "dotenv-checker -s .env.example -e .env",
     "lint": "nx run-many --all --target=lint --parallel",
     "prepare": "husky install && yarn env-check",
-    "prepare:db": "prisma:migrate && prisma:generate && prisma:push",
+    "prepare:db": "yarn prisma:migrate && yarn prisma:generate && yarn prisma:push",
     "prisma:generate": "prisma generate --schema=./libs/models/src/prisma/prisma.schema",
     "prisma:migrate": "prisma migrate dev --schema=./libs/models/src/prisma/prisma.schema",
     "prisma:push": "prisma db push --schema=./libs/models/src/prisma/prisma.schema",


### PR DESCRIPTION
Fixes # (issue)
`yarn prepare:db` script was trying execute other yarn scripts without `yarn` as script executer.
fix by add `yarn` to the start of the script.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

